### PR TITLE
docs(github): Fix GitHub Issue templates not showing

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: 'bug', 'priority:low'
+labels: bug, "priority:low"
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: 'feature', 'priority:low'
+labels: feature, "priority:low"
 assignees: ''
 
 ---


### PR DESCRIPTION
## Related issue

Fixes #21

## Type of Change

- [ ] **Feat**: Change which adds functionality/new feature
- [x] **Fix**: Change which fixes an issue
- [ ] **Refactor**: Change which improves the structure of the code
- [ ] **Docs**: Change which improves documentation

## Description

Fix invalid syntax in YAML frontmatter of GitHub issue templates.

## Screenshot 

## Testing

![Screen Shot 2022-01-15 at 10 11 54 AM](https://user-images.githubusercontent.com/55090719/149626772-5e80ee4c-5aa3-4755-bc0e-53dd70dbb85c.png)


## Note
The title of your PR should follow this format: `[Type](area): Title`