### PR TITLE
feature: Add more colors into tailwind

### DIFF
--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,13 +1,19 @@
 module.exports = {
-  content: ['./src/**/*.{js,jsx,ts,tsx}'],
+  content: ["./src/**/*.{js,jsx,ts,tsx}"],
   theme: {
-    extend: {},
-    fontFamily: {
-      sans: ['Montserrat', 'sans-serif'],
+    extend: {
+      colors: {
+        primary: "#F06C9B",
+        secondary: "#B0228C",
+        "medium-gray": "#000000A8", // input text color
+        "light-gray": "#E6E6E6", // message text background
+        orange: "#FFCD69", // game title text color
+        green: "#00BA66", // matching answer text color
+        purple: "#662E63", // game background color
+      },
     },
-    colors: {
-      primary: '#f06c9b',
-      secondary: '#b0228c',
+    fontFamily: {
+      monts: ["Montserrat", "sans-serif"],
     },
   },
   plugins: [],


### PR DESCRIPTION
## Related issue
- None

Fixes #91 

## Type of Change

- [x] **Feat**: Change which adds functionality/new feature
- [ ] **Fix**: Change which fixes an issue
- [ ] **Refactor**: Change which improves the structure of the code
- [ ] **Docs**: Change which improves documentation

## Description

- Add more colors into `tailwind.config.js` for reusability.
- Move `colors` inside `extend` to avoid default colors overriding.

## Screenshot 
![image](https://user-images.githubusercontent.com/44437742/151431079-d8181f11-4b66-48e9-8f2e-2c830ee8f469.png)