### PR TITLE
fix(mongo): Convert Date object to ISODate

### DIFF
--- a/scripts/db/init/chat-rooms-init.js
+++ b/scripts/db/init/chat-rooms-init.js
@@ -14,7 +14,7 @@ db.chat_rooms.insertMany([
       messages: [
         {
           messageID: ObjectId("61e760eefc13ae08fd000154"),
-          createdAt: { $date: "2002-04-10T02:26:59.000Z" },
+          createdAt: ISODate("2002-04-10T02:26:59.000Z"),
           sendBy: ObjectId("6199d9abf6a0af305d000285"),
           isSeen: false,
           content: "4d22094f3af4b0c5afb8eff1980c9b5fc5b41404",
@@ -27,7 +27,7 @@ db.chat_rooms.insertMany([
         },
         {
           messageID: ObjectId("61e760eefc13ae08fd000155"),
-          createdAt: { $date: "2015-06-09T05:52:35.000Z" },
+          createdAt: ISODate("2015-06-09T05:52:35.000Z"),
           sendBy: ObjectId("6199d9abf6a0af305d000286"),
           isSeen: false,
           content: "4d22094f3af4b0c5afb8eff1980c9b5fc5b41404",
@@ -40,7 +40,7 @@ db.chat_rooms.insertMany([
         },
         {
           messageID: ObjectId("61e760eefc13ae08fd000156"),
-          createdAt: { $date: "2008-06-03T22:48:41.000Z" },
+          createdAt: ISODate("2008-06-03T22:48:41.000Z"),
           sendBy: ObjectId("6199d9abf6a0af305d000285"),
           isSeen: false,
           content: "4d22094f3af4b0c5afb8eff1980c9b5fc5b41404",
@@ -53,7 +53,7 @@ db.chat_rooms.insertMany([
         },
         {
           messageID: ObjectId("61e760eefc13ae08fd000157"),
-          createdAt: { $date: "1999-12-09T23:23:00.000Z" },
+          createdAt: ISODate("1999-12-09T23:23:00.000Z"),
           sendBy: ObjectId("6199d9abf6a0af305d000286"),
           isSeen: false,
           content: "4d22094f3af4b0c5afb8eff1980c9b5fc5b41404",
@@ -66,7 +66,7 @@ db.chat_rooms.insertMany([
         },
         {
           messageID: ObjectId("61e760eefc13ae08fd000158"),
-          createdAt: { $date: "1996-10-21T20:59:34.000Z" },
+          createdAt: ISODate("1996-10-21T20:59:34.000Z"),
           sendBy: ObjectId("6199d9abf6a0af305d000285"),
           isSeen: true,
           content: "4d22094f3af4b0c5afb8eff1980c9b5fc5b41404",
@@ -93,7 +93,7 @@ db.chat_rooms.insertMany([
       messages: [
         {
           messageID: ObjectId("61e760eefc13ae08fd00015a"),
-          createdAt: { $date: "1994-05-31T02:03:37.000Z" },
+          createdAt: ISODate("1994-05-31T02:03:37.000Z"),
           sendBy: ObjectId("6199d9abf6a0af3047000286"),
           isSeen: true,
           content: "4d22094f3af4b0c5afb8eff1980c9b5fc5b41404",
@@ -106,7 +106,7 @@ db.chat_rooms.insertMany([
         },
         {
           messageID: ObjectId("61e760eefc13ae08fd00015b"),
-          createdAt: { $date: "1994-12-31T05:23:17.000Z" },
+          createdAt: ISODate("1994-12-31T05:23:17.000Z"),
           sendBy: ObjectId("6199d9abf6a0af3047000286"),
           isSeen: false,
           content: "4d22094f3af4b0c5afb8eff1980c9b5fc5b41404",
@@ -133,7 +133,7 @@ db.chat_rooms.insertMany([
       messages: [
         {
           messageID: ObjectId("61e760eefc13ae08fd00015d"),
-          createdAt: { $date: "2003-02-04T15:05:03.000Z" },
+          createdAt: ISODate("2003-02-04T15:05:03.000Z"),
           sendBy: ObjectId("6199d9abf6a0af3064000283"),
           isSeen: false,
           content: "4d22094f3af4b0c5afb8eff1980c9b5fc5b41404",
@@ -146,7 +146,7 @@ db.chat_rooms.insertMany([
         },
         {
           messageID: ObjectId("61e760eefc13ae08fd00015e"),
-          createdAt: { $date: "2012-10-17T22:01:47.000Z" },
+          createdAt: ISODate("2012-10-17T22:01:47.000Z"),
           sendBy: ObjectId("6199d9abf6a0af3064000283"),
           isSeen: false,
           content: "4d22094f3af4b0c5afb8eff1980c9b5fc5b41404",
@@ -159,7 +159,7 @@ db.chat_rooms.insertMany([
         },
         {
           messageID: ObjectId("61e760eefc13ae08fd00015f"),
-          createdAt: { $date: "1996-07-19T11:42:14.000Z" },
+          createdAt: ISODate("1996-07-19T11:42:14.000Z"),
           sendBy: ObjectId("6199d9abf6a0af3064000284"),
           isSeen: false,
           content: "4d22094f3af4b0c5afb8eff1980c9b5fc5b41404",
@@ -172,7 +172,7 @@ db.chat_rooms.insertMany([
         },
         {
           messageID: ObjectId("61e760eefc13ae08fd000160"),
-          createdAt: { $date: "2013-01-19T15:08:11.000Z" },
+          createdAt: ISODate("2013-01-19T15:08:11.000Z"),
           sendBy: ObjectId("6199d9abf6a0af3064000284"),
           isSeen: false,
           content: "4d22094f3af4b0c5afb8eff1980c9b5fc5b41404",
@@ -199,7 +199,7 @@ db.chat_rooms.insertMany([
       messages: [
         {
           messageID: ObjectId("61e760eefc13ae08fd000162"),
-          createdAt: { $date: "2018-12-21T10:08:18.000Z" },
+          createdAt: ISODate("2018-12-21T10:08:18.000Z"),
           sendBy: ObjectId("6199d9abf6a0af30a0000286"),
           isSeen: true,
           content: "4d22094f3af4b0c5afb8eff1980c9b5fc5b41404",
@@ -212,7 +212,7 @@ db.chat_rooms.insertMany([
         },
         {
           messageID: ObjectId("61e760eefc13ae08fd000163"),
-          createdAt: { $date: "1991-04-29T20:53:46.000Z" },
+          createdAt: ISODate("1991-04-29T20:53:46.000Z"),
           sendBy: ObjectId("6199d9abf6a0af30a0000285"),
           isSeen: true,
           content: "4d22094f3af4b0c5afb8eff1980c9b5fc5b41404",
@@ -225,7 +225,7 @@ db.chat_rooms.insertMany([
         },
         {
           messageID: ObjectId("61e760eefc13ae08fd000164"),
-          createdAt: { $date: "1992-10-11T23:56:43.000Z" },
+          createdAt: ISODate("1992-10-11T23:56:43.000Z"),
           sendBy: ObjectId("6199d9abf6a0af30a0000285"),
           isSeen: false,
           content: "4d22094f3af4b0c5afb8eff1980c9b5fc5b41404",
@@ -238,7 +238,7 @@ db.chat_rooms.insertMany([
         },
         {
           messageID: ObjectId("61e760eefc13ae08fd000165"),
-          createdAt: { $date: "1996-05-27T11:04:52.000Z" },
+          createdAt: ISODate("1996-05-27T11:04:52.000Z"),
           sendBy: ObjectId("6199d9abf6a0af30a0000286"),
           isSeen: false,
           content: "4d22094f3af4b0c5afb8eff1980c9b5fc5b41404",
@@ -265,7 +265,7 @@ db.chat_rooms.insertMany([
       messages: [
         {
           messageID: ObjectId("61e760eefc13ae08fd000167"),
-          createdAt: { $date: "1998-02-11T10:08:34.000Z" },
+          createdAt: ISODate("1998-02-11T10:08:34.000Z"),
           sendBy: ObjectId("6199d9abf6a0af308e000283"),
           isSeen: false,
           content: "4d22094f3af4b0c5afb8eff1980c9b5fc5b41404",
@@ -278,7 +278,7 @@ db.chat_rooms.insertMany([
         },
         {
           messageID: ObjectId("61e760eefc13ae08fd000168"),
-          createdAt: { $date: "1993-10-21T16:34:29.000Z" },
+          createdAt: ISODate("1993-10-21T16:34:29.000Z"),
           sendBy: ObjectId("6199d9abf6a0af308e000282"),
           isSeen: false,
           content: "4d22094f3af4b0c5afb8eff1980c9b5fc5b41404",
@@ -291,7 +291,7 @@ db.chat_rooms.insertMany([
         },
         {
           messageID: ObjectId("61e760eefc13ae08fd000169"),
-          createdAt: { $date: "1991-06-07T13:09:41.000Z" },
+          createdAt: ISODate("1991-06-07T13:09:41.000Z"),
           sendBy: ObjectId("6199d9abf6a0af308e000282"),
           isSeen: true,
           content: "4d22094f3af4b0c5afb8eff1980c9b5fc5b41404",
@@ -304,7 +304,7 @@ db.chat_rooms.insertMany([
         },
         {
           messageID: ObjectId("61e760eefc13ae08fd00016a"),
-          createdAt: { $date: "1995-01-16T10:11:20.000Z" },
+          createdAt: ISODate("1995-01-16T10:11:20.000Z"),
           sendBy: ObjectId("6199d9abf6a0af308e000283"),
           isSeen: false,
           content: "4d22094f3af4b0c5afb8eff1980c9b5fc5b41404",

--- a/scripts/db/init/users-init.js
+++ b/scripts/db/init/users-init.js
@@ -8,7 +8,7 @@ db.users.insertMany([
     firstName: "Franchot",
     lastName: "MacKeague",
     email: "fmackeague0@imageshack.us",
-    dob: { $date: "2019-07-28T08:01:10.000Z" },
+    dob: ISODate("2019-07-28T08:01:10.000Z"),
     sex: "Male",
     location: {
       city: "Nambak Tengah",
@@ -66,7 +66,7 @@ db.users.insertMany([
     firstName: "Hillier",
     lastName: "Sewley",
     email: "hsewley1@disqus.com",
-    dob: { $date: "2005-05-02T16:44:22.000Z" },
+    dob: ISODate("2005-05-02T16:44:22.000Z"),
     sex: "Female",
     location: {
       city: "Zhangshui",
@@ -120,7 +120,7 @@ db.users.insertMany([
     firstName: "Doyle",
     lastName: "Kemish",
     email: "dkemish2@kickstarter.com",
-    dob: { $date: "2002-08-23T05:06:00.000Z" },
+    dob: ISODate("2002-08-23T05:06:00.000Z"),
     sex: "Male",
     location: {
       city: "Biljača",
@@ -169,7 +169,7 @@ db.users.insertMany([
     firstName: "Wilfred",
     lastName: "Purkins",
     email: "wpurkins3@pen.io",
-    dob: { $date: "2009-10-03T18:32:54.000Z" },
+    dob: ISODate("2009-10-03T18:32:54.000Z"),
     sex: "Female",
     location: {
       city: "Hualfín",
@@ -214,7 +214,7 @@ db.users.insertMany([
     firstName: "Elna",
     lastName: "Marcroft",
     email: "emarcroft4@forbes.com",
-    dob: { $date: "2017-09-27T11:31:32.000Z" },
+    dob: ISODate("2017-09-27T11:31:32.000Z"),
     sex: "Male",
     location: {
       city: "Pau",
@@ -270,7 +270,7 @@ db.users.insertMany([
     firstName: "Jade",
     lastName: "Whitebread",
     email: "jwhitebread5@nsw.gov.au",
-    dob: { $date: "2014-10-17T16:49:10.000Z" },
+    dob: ISODate("2014-10-17T16:49:10.000Z"),
     sex: "Female",
     location: {
       city: "Al Badārī",
@@ -318,7 +318,7 @@ db.users.insertMany([
     firstName: "Onida",
     lastName: "Simpson",
     email: "osimpson6@nba.com",
-    dob: { $date: "2005-04-11T17:21:45.000Z" },
+    dob: ISODate("2005-04-11T17:21:45.000Z"),
     sex: "Female",
     location: {
       city: "‘Ābūd",
@@ -381,7 +381,7 @@ db.users.insertMany([
     firstName: "Brendon",
     lastName: "Seaborne",
     email: "bseaborne7@bloglines.com",
-    dob: { $date: "2002-01-31T15:24:38.000Z" },
+    dob: ISODate("2002-01-31T15:24:38.000Z"),
     sex: "Female",
     location: {
       city: "Colcabamba",
@@ -444,7 +444,7 @@ db.users.insertMany([
     firstName: "George",
     lastName: "Bayfield",
     email: "gbayfield8@alibaba.com",
-    dob: { $date: "2009-01-20T05:07:27.000Z" },
+    dob: ISODate("2009-01-20T05:07:27.000Z"),
     sex: "Female",
     location: {
       city: "Jetafe",
@@ -498,7 +498,7 @@ db.users.insertMany([
     firstName: "Orazio",
     lastName: "Gristwood",
     email: "ogristwood9@google.cn",
-    dob: { $date: "2016-07-25T07:43:45.000Z" },
+    dob: ISODate("2016-07-25T07:43:45.000Z"),
     sex: "Male",
     location: {
       city: "Luoyang",
@@ -543,7 +543,7 @@ db.users.insertMany([
     firstName: "Jacinta",
     lastName: "Verick",
     email: "jvericka@weather.com",
-    dob: { $date: "2014-11-16T21:51:53.000Z" },
+    dob: ISODate("2014-11-16T21:51:53.000Z"),
     sex: "Male",
     location: {
       city: "Bayshint",
@@ -615,7 +615,7 @@ db.users.insertMany([
     firstName: "Ferrell",
     lastName: "Reah",
     email: "freahb@youtube.com",
-    dob: { $date: "2001-11-14T19:43:42.000Z" },
+    dob: ISODate("2001-11-14T19:43:42.000Z"),
     sex: "Female",
     location: {
       city: "Nîmes",
@@ -654,7 +654,7 @@ db.users.insertMany([
     firstName: "Raye",
     lastName: "Streatfeild",
     email: "rstreatfeildc@washington.edu",
-    dob: { $date: "2002-11-28T07:25:36.000Z" },
+    dob: ISODate("2002-11-28T07:25:36.000Z"),
     sex: "Female",
     location: {
       city: "Bum Bum",
@@ -717,7 +717,7 @@ db.users.insertMany([
     firstName: "Jeffry",
     lastName: "Floweth",
     email: "jflowethd@pen.io",
-    dob: { $date: "2021-07-07T08:48:40.000Z" },
+    dob: ISODate("2021-07-07T08:48:40.000Z"),
     sex: "Female",
     location: {
       city: "Vila de Rei",
@@ -774,7 +774,7 @@ db.users.insertMany([
     firstName: "Rollins",
     lastName: "Woodham",
     email: "rwoodhame@admin.ch",
-    dob: { $date: "2021-08-18T05:04:18.000Z" },
+    dob: ISODate("2021-08-18T05:04:18.000Z"),
     sex: "Male",
     location: {
       city: "Karpushikha",
@@ -837,7 +837,7 @@ db.users.insertMany([
     firstName: "Gris",
     lastName: "Philipeau",
     email: "gphilipeauf@bluehost.com",
-    dob: { $date: "2005-03-11T00:49:45.000Z" },
+    dob: ISODate("2005-03-11T00:49:45.000Z"),
     sex: "Male",
     location: {
       city: "Blainville",
@@ -900,7 +900,7 @@ db.users.insertMany([
     firstName: "Phaidra",
     lastName: "Lopez",
     email: "plopezg@archive.org",
-    dob: { $date: "2006-07-24T23:14:40.000Z" },
+    dob: ISODate("2006-07-24T23:14:40.000Z"),
     sex: "Male",
     location: {
       city: "Taksimo",
@@ -964,7 +964,7 @@ db.users.insertMany([
     firstName: "Artie",
     lastName: "Dutt",
     email: "adutth@goo.gl",
-    dob: { $date: "2007-08-11T16:43:21.000Z" },
+    dob: ISODate("2007-08-11T16:43:21.000Z"),
     sex: "Female",
     location: {
       city: "Baikui",
@@ -1015,7 +1015,7 @@ db.users.insertMany([
     firstName: "Michael",
     lastName: "Wraxall",
     email: "mwraxalli@spotify.com",
-    dob: { $date: "2009-06-18T05:58:19.000Z" },
+    dob: ISODate("2009-06-18T05:58:19.000Z"),
     sex: "Agender",
     location: {
       city: "Buyun",
@@ -1073,7 +1073,7 @@ db.users.insertMany([
     firstName: "Ernest",
     lastName: "Lodemann",
     email: "elodemannj@dion.ne.jp",
-    dob: { $date: "2016-04-24T21:30:43.000Z" },
+    dob: ISODate("2016-04-24T21:30:43.000Z"),
     sex: "Female",
     location: {
       city: "Shatian",


### PR DESCRIPTION
## Related issue

Fixes #131 

## Type of Change

- [ ] **Feat**: Change which adds functionality/new feature
- [x] **Fix**: Change which fixes an issue
- [ ] **Refactor**: Change which improves the structure of the code
- [ ] **Docs**: Change which improves documentation

## Description

Convert any Date field that stores an object containing a date to `ISODate(<date>)`. Any Date field should now return a string of Unix timestamp.

## Screenshot 

![Screen Shot 2022-02-04 at 6 38 42 PM](https://user-images.githubusercontent.com/55090719/152617468-e4c13a59-4425-4310-a99c-352f999495bf.png)

![Screen Shot 2022-02-04 at 6 38 49 PM](https://user-images.githubusercontent.com/55090719/152617472-7ceca0a6-8fc4-43c7-9898-0394bb951a57.png)

## Testing

Described in Screenshot

## Note
The title of your PR should follow this format: `[Type](area): Title`