### PR TITLE
feature: Persist auth token

### DIFF
--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -4,10 +4,31 @@ import "./styles/index.css";
 import App from "./App";
 import reportWebVitals from "./reportWebVitals";
 
-import { ApolloClient, InMemoryCache, ApolloProvider } from "@apollo/client";
+import {
+  ApolloClient,
+  createHttpLink,
+  InMemoryCache,
+  ApolloProvider,
+} from "@apollo/client";
+import { setContext } from "@apollo/client/link/context";
+
+const httpLink = createHttpLink({
+  uri: process.env.REACT_APP_GRAPHQL_URI,
+});
+
+const authLink = setContext((_, { headers }) => {
+  const token = localStorage.getItem("token");
+
+  return {
+    headers: {
+      ...headers,
+      authorization: token ? `Bearer ${token}` : "",
+    },
+  };
+});
 
 const apolloClient = new ApolloClient({
-  uri: process.env.REACT_APP_GRAPHQL_URI,
+  link: authLink.concat(httpLink),
   cache: new InMemoryCache(),
 });
 

--- a/frontend/src/pages/Modal/Signin.js
+++ b/frontend/src/pages/Modal/Signin.js
@@ -10,7 +10,7 @@ const Signin = (props) => {
   const [password, setPassword] = useState("");
   const [err, setErr] = useState("");
   const [showSignInModal, setShowSignInModal] = useState(true);
-  const [login, { error }] = useMutation(USER_LOGIN_MUTATION);
+  const [login] = useMutation(USER_LOGIN_MUTATION);
   const clearErr = () => setErr("");
 
   const handleClick = () => {
@@ -24,12 +24,14 @@ const Signin = (props) => {
           email: email,
           password: password,
         },
+        onError: (error) => {
+          setErr(error);
+        },
+        onCompleted: (data) => {
+          localStorage.setItem("token", data.login.token);
+          props.handleShow();
+        },
       });
-      if (error) {
-        setErr(error);
-      } else {
-        props.handleShow();
-      }
     }
   };
 

--- a/frontend/src/pages/Modal/Signup.js
+++ b/frontend/src/pages/Modal/Signup.js
@@ -97,13 +97,14 @@ const Signup = (props) => {
           dob: new Date(`${year}, ${month}, ${date}`),
           sex: gender,
         },
+        onError: (error) => {
+          setErr(error);
+        },
+        onCompleted: (data) => {
+          localStorage.setItem("token", data.signup.token);
+          props.handleShow();
+        },
       });
-
-      if (error) {
-        setErr(error);
-      } else {
-        props.handleShow();
-      }
     }
   };
 


### PR DESCRIPTION
## Related issue

Fixes #139 

## Type of Change

- [x] **Feat**: Change which adds functionality/new feature
- [ ] **Fix**: Change which fixes an issue
- [ ] **Refactor**: Change which improves the structure of the code
- [ ] **Docs**: Change which improves documentation

## Description

Auth token, returned on successful log-in or account registration, is now saved to local storage. The token is also added to HTTP Authorization header.

## Screenshot 

## Testing


## Note
The title of your PR should follow this format: `[Type](area): Title`