### PR TITLE
feature: build delete account confirmation modal

### DIFF
--- a/frontend/src/components/Buttons/RoundedButton.js
+++ b/frontend/src/components/Buttons/RoundedButton.js
@@ -3,7 +3,7 @@ import React from "react";
 function RoundedButton(props) {
   return (
     <button
-      className={`${props.borderColor} ${props.bgColor} ${props.textColor} ${props.fontSize} ${props.hover} ${props.paddingLR} ${props.paddingTB} ${props.fontWeight} border-2 rounded`}
+      className={`${props.borderColor} ${props.bgColor} ${props.textColor} ${props.fontSize} ${props.hover} ${props.paddingLR} ${props.paddingTB} ${props.fontWeight} ${props.btnStyle} border-2 rounded`}
       onClick={props.handleClick}
     >
       {props.btnName}

--- a/frontend/src/graphql/mutations/DeleteAccount.js
+++ b/frontend/src/graphql/mutations/DeleteAccount.js
@@ -1,0 +1,10 @@
+import { gql } from "@apollo/client";
+
+export const DELETE_ACCOUNT_MUTATION = gql`
+  mutation deleteAccount {
+    deleteAccount {
+      success
+      message
+    }
+  }
+`;

--- a/frontend/src/pages/Modal/Confirmation.js
+++ b/frontend/src/pages/Modal/Confirmation.js
@@ -1,0 +1,55 @@
+import RoundedButton from "../../components/Buttons/RoundedButton";
+
+const Confirmation = (props) => {
+  return (
+    <div
+      className={`bg-black bg-opacity-50 absolute overflow-auto inset-0 flex justify-center items-center h-screen`}
+    >
+      <div className="px-8 bg-white w-5/6 lg:w-1/3 md:max-w-3xl rounded-lg ">
+        <h3 className="text-primary font-bold pt-5 pb-3 text-2xl text-center">
+          {props.title}
+        </h3>
+        {props.err && (
+          <span className="text-red-600 font-medium">{props.err}</span>
+        )}
+        {/* Contains content of the confirmation */}
+        <div className="text-center text-lg mt-5 mb-3">{props.content}</div>
+        {/* Contains the final statement for the confirmation */}
+        {props.confirmState}
+        <div className={`mt-3 pb-8 text-center ${props.hideBtn}`}>
+          <div className="inline-block mr-2">
+            <RoundedButton
+              btnName={props.btn1Name}
+              btnStyle={props.btn1Style}
+              handleClick={props.handleCancel}
+            />
+          </div>
+
+          <div className="inline-block ml-2">
+            <RoundedButton
+              btnStyle={props.btn2Style}
+              btnName={props.btn2Name}
+              handleClick={props.handleConfirm}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+Confirmation.defaultProps = {
+  title: "",
+  content: "",
+  confirmState: "", // used in game modal
+  btn1Name: "No",
+  btn1Style:
+    "pr-10 pl-10 py-2 text-sm hover:bg-green hover:text-white hover:border-green font-bold",
+  btn2Name: "Yes",
+  btn2Style:
+    "pr-10 pl-10 py-2 text-sm bg-white text-primary hover:bg-red-500 hover:text-white hover:border-red-500 font-bold",
+  hideBtn: "", // used to hide buttons in game request
+  err: "", // err might receive from edit page
+};
+
+export default Confirmation;


### PR DESCRIPTION
## Related issue

Fixes #163 

## Type of Change

- [x] **Feat**: Change which adds functionality/new feature
- [ ] **Fix**: Change which fixes an issue
- [ ] **Refactor**: Change which improves the structure of the code
- [ ] **Docs**: Change which improves documentation

## Description

I realized that the confirmation modal can be built in a way we can reuse it for other modals (especially game modals). Later on, we can make use of this component for issues #50 #62 

In the process of improving `edit-page`, I will link this to the `Delete account` button.

## Screenshot 

![image](https://user-images.githubusercontent.com/44437742/154217225-b0bb485c-c7d1-4881-993a-f299a5bc06da.png)
![image](https://user-images.githubusercontent.com/44437742/154217284-23ed3209-c9fe-48f6-b928-025b502ed21f.png)
![image](https://user-images.githubusercontent.com/44437742/154217311-bfd41edf-1fe8-42f7-b58f-281afbaeed4c.png)


## Note
The title of your PR should follow this format: `[Type](area): Title`