### PR TITLE
chore: use different env for cryptr

### DIFF
--- a/backend/src/graphql/ChatRoom/datasource.js
+++ b/backend/src/graphql/ChatRoom/datasource.js
@@ -2,6 +2,7 @@ const { DataSource } = require("apollo-datasource");
 const { ApolloError } = require("apollo-server-core");
 const Cryptr = require("cryptr");
 const mongoose = require("mongoose");
+require("dotenv").config();
 
 const ChatRoom = require("../../schemas/ChatRoom/ChatRoom");
 const UserTypeEnum = require("../../enum/UserType");
@@ -18,7 +19,10 @@ class ChatRoomAPI extends DataSource {
 
       const roomId = mongoose.Types.ObjectId();
 
-      const secretKey = roomId.toString();
+      let secretKey = process.env.ENCRYPT_KEY;
+      if (process.env.NODE_ENV === "production") {
+        secretKey = roomId.toString();
+      }
 
       const cryptr = new Cryptr(secretKey);
 
@@ -79,7 +83,12 @@ class ChatRoomAPI extends DataSource {
   async sendMessageToChatRoom(roomId, content, photo = null, sendBy) {
     const id = mongoose.Types.ObjectId();
 
-    const cryptr = new Cryptr(roomId);
+    let secretKey = process.env.ENCRYPT_KEY;
+    if (process.env.NODE_ENV === "production") {
+      secretKey = roomId;
+    }
+
+    const cryptr = new Cryptr(secretKey);
 
     // create a returned message
     const message = {
@@ -109,7 +118,11 @@ class ChatRoomAPI extends DataSource {
   async getMessages(roomId) {
     const chatRoom = await this.getChatRoomById(roomId);
 
-    const cryptr = new Cryptr(roomId);
+    let secretKey = process.env.ENCRYPT_KEY;
+    if (process.env.NODE_ENV === "production") {
+      secretKey = roomId;
+    }
+    const cryptr = new Cryptr(secretKey);
 
     const messages = chatRoom.history.messages.map((message) => {
       return {


### PR DESCRIPTION
## Related issue

Tags #201 

## Type of Change

- [ ] **Feat**: Change which adds functionality/new feature
- [X] **Fix**: Change which fixes an issue
- [ ] **Refactor**: Change which improves the structure of the code
- [ ] **Docs**: Change which improves documentation

## Description
This PR updates `cryptr` so that it will use the same `key` when running development mode and roomId key for production mode

