### PR TITLE
feature/56-build-partner-section

### DIFF
--- a/frontend/src/components/Chat/ChatPartner.js
+++ b/frontend/src/components/Chat/ChatPartner.js
@@ -1,0 +1,69 @@
+import { useState } from "react";
+import Input from "../Input/Input";
+import defaultAvt from "../../assets/mock_avatar.png";
+
+const ChatPartner = (props) => {
+  const [searchInputText, setSearchInputText] = useState("");
+  const searchInputHandler = (e) => {
+    setSearchInputText(e.target.value.toLowerCase());
+  };
+
+  const roomsData = props.data.map((chatRoom) => {
+    const {
+      partner: {
+        id: partnerId,
+        avatar: { small: partnerAvatar },
+        firstName: partnerName,
+      },
+      history,
+    } = chatRoom;
+
+    const latestMsg = history[history.length - 1];
+    const sentBy = latestMsg.sendBy === partnerId ? partnerName : "You";
+    const latestMsgContent = !latestMsg.photo
+      ? `${latestMsg.content.split(" ").slice(0, 5).join(" ")}...`
+      : `${sentBy} sent a photo.`;
+
+    return {
+      partnerAvatar,
+      partnerName,
+      latestMsgContent,
+    };
+  });
+
+  const roomsDataFiltered = roomsData.filter((room) => {
+    if (searchInputText === "") {
+      return room;
+    } else {
+      return room.partnerName.toLowerCase().includes(searchInputText);
+    }
+  });
+
+  return (
+    <section className="w-1/3 min-h-[85%] max-h-[85%] pr-6 mr-6 border-r-[1px] border-r-primary">
+      <Input
+        type="text"
+        width="w-full"
+        placeholder="Search"
+        onChange={searchInputHandler}
+      />
+      {roomsDataFiltered.map((room) => (
+        <div id="partner-card" className="mt-6 w-full">
+          <div className="flex items-center py-4">
+            <img
+              src={room.partnerAvatar ? room.partnerAvatar : defaultAvt}
+              alt="user's avatar"
+              className="object-contain w-20 h-20 mr-4 rounded-full"
+            />
+            <div className="w-full text-ellipsis">
+              <p className="text-lg font-bold">{room.partnerName}</p>
+              <p>{room.latestMsgContent}</p>
+            </div>
+          </div>
+        </div>
+      ))}
+    </section>
+  );
+};
+
+export default ChatPartner;

--- a/frontend/src/components/Chat/ChatWindow.js
+++ b/frontend/src/components/Chat/ChatWindow.js
@@ -8,7 +8,7 @@ function ChatWindow({ data }) {
   const [showEmoji, setShowEmoji] = useState(false);
 
   return (
-    <div className="flex flex-col gap-y-2 container col-start-2 w-3/4 h-full">
+    <div className="flex flex-col gap-y-2 container col-start-2 w-2/3 h-full">
       <ChatHeader
         avatar={data.partner.avatar.small}
         firstName={data.partner.firstName}

--- a/frontend/src/pages/Chat/Chat.js
+++ b/frontend/src/pages/Chat/Chat.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import Spinner from "../../components/Spinner/Spinner";
 import ChatWindow from "../../components/Chat/ChatWindow";
+import ChatPartner from "../../components/Chat/ChatPartner";
 import Navbar from "../../components/Navbar";
 import { GET_MESSAGE } from "../../graphql/subscriptions/Chat";
 import { GET_CHAT_ROOMS } from "../../graphql/queries/Chat";
@@ -48,7 +49,8 @@ function Chat() {
     return (
       <div className="h-screen">
         <Navbar />
-        <section className="min-h-[85%] max-h-[85%] flex ">
+        <section className="container mx-auto py-5 md:p-5 min-h-[85%] max-h-[85%] flex">
+          <ChatPartner data={data.chatRooms} />
           <ChatWindow data={data.chatRooms[0]} />
         </section>
       </div>


### PR DESCRIPTION
## Related issue

Fixes #56 

## Type of Change

- [x] **Feat**: Change which adds functionality/new feature
- [ ] **Fix**: Change which fixes an issue
- [ ] **Refactor**: Change which improves the structure of the code
- [ ] **Docs**: Change which improves documentation

## Description

- Added search bar to look up for partner
- Added partner card to display partner avatar, name, and a preview of the latest message

## Screenshot 

<img width="1440" alt="Screen Shot 2022-02-20 at 10 05 17 PM" src="https://user-images.githubusercontent.com/59778930/154885162-d633e5cf-6fa0-4748-bab3-237d470bd393.png">
<img width="1440" alt="Screen Shot 2022-02-20 at 10 06 21 PM" src="https://user-images.githubusercontent.com/59778930/154885164-2e2b1e91-85d3-4903-b2b2-786266c2c9be.png">

## Testing

Has this pull request been tested?

- Yes

Please describe shortly how you tested it:

- Log in as [charlie.black@seeksi.com](mailto:charlie.black@seeksi.com) and navigate to Chat page
- Sent a message in the current chat window and refresh the page to see the latest message appeared in the message preview
- To search for a user, simply enter inside the search bar. Note that if no partner is found, the section won't display any partner card, and when the search bar is empty, the section should display all partner cards

## Note
The title of your PR should follow this format: `[Type](area): Title`