### PR TITLE
fix: check partner online status before sending game request

### DIFF
--- a/backend/src/graphql/GameRequest/resolvers.js
+++ b/backend/src/graphql/GameRequest/resolvers.js
@@ -1,3 +1,4 @@
+const { ApolloError } = require("apollo-server-core");
 const { PubSub, withFilter } = require("graphql-subscriptions");
 const mongoose = require("mongoose");
 
@@ -12,6 +13,12 @@ const mutations = {
     { dataSources, req, userAuthentication }
   ) => {
     userAuthentication(req.user);
+
+    // check partner's online status
+    const isPartnerOnline = dataSources.userStatusAPI.isOnline(args.to);
+    if (!isPartnerOnline) {
+      throw new ApolloError("Partner is offline");
+    }
 
     const gameRequest = await dataSources.gameRequestAPI.sendGameRequestTo(
       req.user.userId,


### PR DESCRIPTION
## Related issue

Fixes #243 

## Type of Change

- [ ] **Feat**: Change which adds functionality/new feature
- [X] **Fix**: Change which fixes an issue
- [ ] **Refactor**: Change which improves the structure of the code
- [ ] **Docs**: Change which improves documentation

## Description
This PR will check partner online status before send game request to the partner. This will ensure both the user and the partner is online.