### PR TITLE
fix: disable chat after un-matching

### DIFF
--- a/backend/src/graphql/ChatRoom/datasource.js
+++ b/backend/src/graphql/ChatRoom/datasource.js
@@ -176,6 +176,12 @@ class ChatRoomAPI extends DataSource {
 
     await chatroom.save();
   }
+
+  async isChatRoomDisabled(roomId) {
+    const chatRoom = await ChatRoom.findById(roomId);
+
+    return chatRoom.isDisabled;
+  }
 }
 
 module.exports.ChatRoomAPI = ChatRoomAPI;

--- a/backend/src/graphql/ChatRoom/resolvers.js
+++ b/backend/src/graphql/ChatRoom/resolvers.js
@@ -1,3 +1,4 @@
+const { ApolloError } = require("apollo-server-core");
 const { PubSub } = require("graphql-subscriptions");
 
 const pubsub = new PubSub();
@@ -23,6 +24,13 @@ const mutations = {
     const roomId = args.roomId;
     const content = args.content || "";
     const photo = null;
+
+    const isDisabled = await dataSources.chatRoomAPI.isChatRoomDisabled(
+      args.roomId
+    );
+    if (isDisabled) {
+      throw new ApolloError("Chat room has been disabled");
+    }
 
     const message = await dataSources.chatRoomAPI.sendMessageToChatRoom(
       roomId,


### PR DESCRIPTION
## Related issue

Fixes #262 

## Type of Change

- [ ] **Feat**: Change which adds functionality/new feature
- [X] **Fix**: Change which fixes an issue
- [ ] **Refactor**: Change which improves the structure of the code
- [ ] **Docs**: Change which improves documentation

## Description
This PR will not allow users to chat after one has un-matched them, the room will be disabled. This will prevent the case when 2 users are send messages and 1 click un-match, the other one can't send messages right away.