### PR TITLE
fix: disable chat after unmatch

### DIFF
--- a/backend/src/graphql/ChatRoom/resolvers.js
+++ b/backend/src/graphql/ChatRoom/resolvers.js
@@ -26,6 +26,13 @@ const mutations = {
   sendMessage: async (_, args, { dataSources, req, userAuthentication }) => {
     userAuthentication(req.user);
 
+    const isDisabled = await dataSources.chatRoomAPI.isChatRoomDisabled(
+      args.roomId
+    );
+    if (isDisabled) {
+      throw new ApolloError("Chat room has been disabled");
+    }
+
     if (args.photos && Array.isArray(args.photos)) {
       const filePaths = await Promise.all(
         args.photos.map(async (photo) => await writeFileUpload(photo))
@@ -56,13 +63,6 @@ const mutations = {
 
     if (!args.content || typeof args.content !== "string") {
       throw new UserInputError("Invalid message");
-    }
-
-    const isDisabled = await dataSources.chatRoomAPI.isChatRoomDisabled(
-      args.roomId
-    );
-    if (isDisabled) {
-      throw new ApolloError("Chat room has been disabled");
     }
 
     const message = await dataSources.chatRoomAPI.sendMessageToChatRoom(

--- a/frontend/src/components/Chat/ChatInput.js
+++ b/frontend/src/components/Chat/ChatInput.js
@@ -51,20 +51,23 @@ function ChatInput(props) {
   };
 
   const handleSendMessage = () => {
-    sendMessage({
-      variables: {
-        roomId: props.roomId,
-        content: message,
-        photos: uploadImgs,
-      },
-      onError: (err) => {
-        // do something
-        console.log(err);
-      },
-      onCompleted: (data) => {
-        console.log(data);
-      },
-    });
+    if (message !== "" || uploadImgs.length !== 0) {
+      sendMessage({
+        variables: {
+          roomId: props.roomId,
+          content: message,
+          photos: uploadImgs,
+        },
+        onError: (err) => {
+          console.log(err);
+          if (err.message === "Chat room has been disabled") props.refetch();
+          //toaster here
+        },
+        onCompleted: (data) => {
+          console.log(data);
+        },
+      });
+    }
     setMessage("");
     setImages([]);
     setErr("");

--- a/frontend/src/components/Chat/ChatWindow.js
+++ b/frontend/src/components/Chat/ChatWindow.js
@@ -4,7 +4,7 @@ import ChatHeader from "./ChatHeader";
 import ChatInput from "./ChatInput";
 import ChatMessageList from "./ChatMessageList";
 
-function ChatWindow({ data, setShowConfirmation }) {
+function ChatWindow({ data, setShowConfirmation, refetch }) {
   const [showEmoji, setShowEmoji] = useState(false);
 
   return data ? (
@@ -28,6 +28,7 @@ function ChatWindow({ data, setShowConfirmation }) {
           roomId={data.id}
           showEmoji={showEmoji}
           setShowEmoji={setShowEmoji}
+          refetch={refetch}
         />
       )}
     </div>

--- a/frontend/src/pages/Chat/Chat.js
+++ b/frontend/src/pages/Chat/Chat.js
@@ -120,6 +120,7 @@ function Chat() {
           <ChatWindow
             data={data.chatRooms.find((room) => room.id === activeRoomId)}
             setShowConfirmation={setShowConfirmation}
+            refetch={refetch}
           />
         </section>
       </div>


### PR DESCRIPTION
## Related issue

Fixes #272 

## Type of Change

- [ ] **Feat**: Change which adds functionality/new feature
- [x] **Fix**: Change which fixes an issue
- [ ] **Refactor**: Change which improves the structure of the code
- [ ] **Docs**: Change which improves documentation

## Description

- disable chat after unmatch
- disable sending empty message

***Note:** will add toaster later
 
## Screenshot 


https://user-images.githubusercontent.com/55411709/157692984-b2e371a0-5998-4a00-a38f-085edcaf468e.mp4



## Testing

Has this pull request been tested? yes

Please describe shortly how you tested it:
1. Log in as `charlie.black@seeksi.com` and go to `Chat`
2. Log in as `ashley.white@seeksi.com` and go to `Chat`
3. Send an empty message
4. Unmatch
5. Go to the other user and send message

## Note
The title of your PR should follow this format: `[Type](area): Title`