### PR TITLE
fix: Error message not handled properly on failed sign in/ sign up

### DIFF
--- a/frontend/src/pages/Modal/Signin.js
+++ b/frontend/src/pages/Modal/Signin.js
@@ -27,7 +27,7 @@ const Signin = (props) => {
           password: password,
         },
         onError: (error) => {
-          setErr(error);
+          setErr(error.message);
         },
         onCompleted: (data) => {
           localStorage.setItem("token", data.login.token);


### PR DESCRIPTION
## Related issue

Fixes #274 

## Type of Change

- [ ] **Feat**: Change which adds functionality/new feature
- [x] **Fix**: Change which fixes an issue
- [ ] **Refactor**: Change which improves the structure of the code
- [ ] **Docs**: Change which improves documentation

## Description

- Changed argument value passed to `setErr` on failed sign in (mutation error)

```js
// before
setErr(error)

// after
setErr(error.message)
```

## Testing

Has this pull request been tested?

- Yes

Please describe shortly how you tested it:

1. Go to Landing page
2. Sign in or sign up with wrong credentials
 
Error message `Password is not correct` should show up and user still remain in landing page

## Note
The title of your PR should follow this format: `[Type](area): Title`