### PR TITLE
fix: link chat to partner profile

### DIFF
--- a/frontend/src/components/Chat/ChatHeader.js
+++ b/frontend/src/components/Chat/ChatHeader.js
@@ -1,8 +1,10 @@
 import React from "react";
+import { useNavigate } from "react-router-dom";
 import OvalButton from "../Buttons/OvalButton";
 import defaultAvt from "../../assets/mock_avatar.png";
 
 function ChatHeader(props) {
+  const navigate = useNavigate();
   return (
     <div>
       <div className="flex-none container mx-auto py-1 border-b-[1px] border-primary">
@@ -14,11 +16,15 @@ function ChatHeader(props) {
                   props.avatar && !props.isDisabled ? props.avatar : defaultAvt
                 }
                 alt="user avatar"
-                className=" object-contain"
+                className=" object-contain hover:cursor-pointer"
+                onClick={() => navigate(`/user/${props.partnerId}`)}
               />
             </div>
             <div className="mx-3 text-lg text-black self-center">
-              <span className="text-lg font-bold inline-block">
+              <span
+                className="text-lg font-bold inline-block hover:cursor-pointer"
+                onClick={() => navigate(`/user/${props.partnerId}`)}
+              >
                 {props.firstName}
               </span>
               {props.userStatus && (

--- a/frontend/src/components/Chat/ChatWindow.js
+++ b/frontend/src/components/Chat/ChatWindow.js
@@ -21,6 +21,7 @@ function ChatWindow({
     <div className="flex flex-col items-stretch gap-y-2 container col-start-2 w-2/3 h-full">
       <ChatHeader
         avatar={data.partner.avatar.small}
+        partnerId={data.partner.id}
         firstName={data.partner.firstName}
         isDisabled={data.isDisabled}
         userStatus={userStatus}


### PR DESCRIPTION
## Related issue

Fixes #319 

## Type of Change

- [ ] **Feat**: Change which adds functionality/new feature
- [x] **Fix**: Change which fixes an issue
- [ ] **Refactor**: Change which improves the structure of the code
- [ ] **Docs**: Change which improves documentation

## Description

User can now navigate to partner's profile by clicking on partner's name or avatar

![chat](https://user-images.githubusercontent.com/55411709/159138179-2c3617aa-2a3c-44e2-b989-f40c68e862c2.jpg)


## Testing

Has this pull request been tested? yes

Please describe shortly how you tested it:
1. Log in 
2. Go to chat 
3. Select 1 partner
4. Click on name/avatar on ChatHeader


## Note
The title of your PR should follow this format: `[Type](area): Title`