### PR TITLE
bugfix: render images immediately when choosing images

### DIFF
--- a/frontend/src/components/Chat/ChatInput.js
+++ b/frontend/src/components/Chat/ChatInput.js
@@ -144,6 +144,7 @@ function ChatInput(props) {
             id="img"
             accept="image/*"
             onChange={handleChange}
+            onClick={(e) => (e.target.value = "")}
             hidden
           />
           <label htmlFor="img">


### PR DESCRIPTION
## Related issue

Fixes #284 

## Type of Change

- [ ] **Feat**: Change which adds functionality/new feature
- [X] **Fix**: Change which fixes an issue
- [ ] **Refactor**: Change which improves the structure of the code
- [ ] **Docs**: Change which improves documentation

## Description
This PR make changes in chat input to reset a state back to original value, so choosing a new image will set the state to another value which triggers re rendering