### PR TITLE
fix: Add authentication to subscriptions

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -68,7 +68,27 @@ async function startApolloSever() {
     path: "/",
   });
 
-  const serverCleanup = useServer({ schema }, wsServer);
+  const getDynamicContext = (ctx, msg, args) => {
+    if (ctx.connectionParams.authorization) {
+      const req = {
+        headers: {
+          authorization: ctx.connectionParams.authorization,
+        },
+      };
+
+      return { ...middleware(req) };
+    }
+  };
+
+  const serverCleanup = useServer(
+    {
+      schema,
+      context: (ctx, msg, args) => {
+        return getDynamicContext(ctx, msg, args);
+      },
+    },
+    wsServer
+  );
 
   const server = new ApolloServer({
     schema,

--- a/frontend/src/context/websocketContext.js
+++ b/frontend/src/context/websocketContext.js
@@ -18,6 +18,9 @@ const WebSocketProvider = ({ children }) => {
     const wsLink = new GraphQLWsLink(
       createClient({
         url: "ws://localhost:4000/",
+        connectionParams: {
+          authorization: getToken() ? `Bearer ${getToken()}` : "",
+        },
       })
     );
 


### PR DESCRIPTION
## Related issue

Fixes #242 

## Type of Change

- [ ] **Feat**: Change which adds functionality/new feature
- [x] **Fix**: Change which fixes an issue
- [ ] **Refactor**: Change which improves the structure of the code
- [ ] **Docs**: Change which improves documentation

## Description

This PR should add authentication & authorization to GraphQL subscriptions. As a result, the access to the real-time system is limited to only authorized users.

## Screenshot 

https://user-images.githubusercontent.com/55090719/160318286-3b5133e0-8bb8-4c3b-a7d2-3bcaca583446.mov

https://user-images.githubusercontent.com/55090719/160319176-36ec91e4-05ff-4e3d-a19e-0ffdcaac2618.mov

## Testing

- Check if real-time notification and messaging are functional

## Note
The title of your PR should follow this format: `[Type](area): Title`