### PR TITLE
hotfix: Fix incorrect totalReports & totalPages

### DIFF
--- a/backend/src/graphql/Report/datasource.js
+++ b/backend/src/graphql/Report/datasource.js
@@ -75,6 +75,7 @@ class ReportAPI extends DataSource {
       }
 
       let reports = [];
+      const totalReports = await Report.countDocuments(condition);
 
       if (+page && +perPage) {
         page = +page - 1;
@@ -109,10 +110,12 @@ class ReportAPI extends DataSource {
 
       return {
         reports,
+        totalReports,
         page: page + 1,
         limit: perPage,
-        totalReports: reports.length,
-        totalPages: Math.floor(reports.length / perPage) + 1,
+        totalPages:
+          Math.floor(totalReports / perPage) +
+          (totalReports % perPage > 0 ? 1 : 0),
       };
     } catch (err) {
       throw new ApolloError("Internal Server Error");


### PR DESCRIPTION
## Related issue

Fixes #issue-number

## Type of Change

- [ ] **Feat**: Change which adds functionality/new feature
- [x] **Fix**: Change which fixes an issue
- [ ] **Refactor**: Change which improves the structure of the code
- [ ] **Docs**: Change which improves documentation

## Description

This PR should fix the wrong `totalReports` & `totalPages` returned by `getReports()`.

## Screenshot 
N/A

## Testing
N/A

## Note
The title of your PR should follow this format: `[Type](area): Title`