### PR TITLE
hotfix: chat message item alignment bug

### DIFF
--- a/frontend/src/components/Chat/ChatMessageItem.js
+++ b/frontend/src/components/Chat/ChatMessageItem.js
@@ -10,10 +10,10 @@ import "lightgallery/css/lg-zoom.css";
 
 function ChatMessageItem({ message, partnerName }) {
   const currentUserId = jwt_decode(localStorage.getItem("token")).userId;
-  const adminStyle = "place-self-center text-center bg-white text-xs my-0";
-  const userStyle = "place-self-end text-right bg-slate-100 my-1 max-w-[40%]";
+  const adminStyle = "self-center text-center bg-white text-xs my-0";
+  const userStyle = "self-end text-right bg-slate-100 my-1 max-w-[40%]";
   const partnerStyle =
-    "place-self-start text-left border-[1px] border-slate-300 my-1 max-w-[40%]";
+    "self-start text-left border-[1px] border-slate-300 my-1 max-w-[40%]";
 
   const isGameRequest = message.content === "sent a game request";
   const isGameResponse =

--- a/frontend/src/components/Chat/ChatSuggestLines.js
+++ b/frontend/src/components/Chat/ChatSuggestLines.js
@@ -66,7 +66,7 @@ const ChatSuggestLines = (props) => {
       </div>
       {loading && <Spinner />}
       {error && (
-        <div className="italic place-self-center text-xs my-auto mx-auto">
+        <div className="italic self-center text-xs my-auto mx-auto">
           An error occurs, please try again later!
         </div>
       )}

--- a/frontend/src/components/Chat/ChatWindow.js
+++ b/frontend/src/components/Chat/ChatWindow.js
@@ -37,7 +37,7 @@ function ChatWindow({
       />
       {data.isDisabled ? (
         <div className="flex items-center justify-center">
-          <p className="font-medium place-self-center my-auto">
+          <p className="font-medium self-center my-auto">
             🔒 {data.partner.firstName} is unmatched. You are now unable to send
             message to {data.partner.firstName} 🔒
           </p>

--- a/frontend/src/pages/Chat/Chat.js
+++ b/frontend/src/pages/Chat/Chat.js
@@ -354,7 +354,7 @@ function Chat({
       <Navbar handleLogOut={handleLogOut} />
       {roomsLoading && <Spinner />}
       {roomsError && (
-        <div className="italic place-self-center my-auto">
+        <div className="italic self-center my-auto">
           An error occurs, please try again later!
         </div>
       )}


### PR DESCRIPTION
## Related issue

Fixes #issue-number

## Type of Change

- [ ] **Feat**: Change which adds functionality/new feature
- [x] **Fix**: Change which fixes an issue
- [ ] **Refactor**: Change which improves the structure of the code
- [ ] **Docs**: Change which improves documentation

## Description

Inside Chat page, the message item doesn't align properly. This might be the result of the TailwindCSS class `place-self-start` being incompatible on Safari:

![image](https://user-images.githubusercontent.com/59778930/162656573-e8431553-5c7e-4f0c-b33c-a2453e4387bc.png)

- Changed `place-self-start` Tailwind class to `self-start`

Result:

<img width="1440" alt="Screen Shot 2022-04-10 at 10 42 55 PM" src="https://user-images.githubusercontent.com/59778930/162656733-5d6bd83c-b6e7-4ead-96a4-5d386e2cbea2.png">

## Testing

Has this pull request been tested?

- Yes

Please describe shortly how you tested it:

1. Log in to Seeksi using any of the existing user account (I'm using Charlie's account for this PR)
2. Navigate to "Chat" page
3. Click on any chat partner to open the chat window
4. See the message bubble being displayed/rendered onto the screen

## Note
The title of your PR should follow this format: `[Type](area): Title`